### PR TITLE
Add registry authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM alpine:3.6
 RUN apk add --no-cache curl bash
 ADD docker-registry-cleanup.sh /docker-registry-cleanup.sh
+RUN curl -L https://github.com/jessfraz/reg/releases/download/v0.8.0/reg-linux-amd64 -o /usr/local/bin/reg
+RUN chmod a+x /usr/local/bin/reg
 CMD /docker-registry-cleanup.sh

--- a/docker-registry-cleanup.sh
+++ b/docker-registry-cleanup.sh
@@ -22,11 +22,19 @@ fi
 
 #run curl with --insecure?
 if [ "$CURL_INSECURE" == "true" ]; then
-	CURL_INSECURE_ARG=--insecure
+	REG_INSECURE_ARG=--insecure
+fi
+
+if [[ $REGISTRY_USERNAME ]]; then
+	REG_USERNAME_ARG="-u ${REGISTRY_USERNAME}"
+fi
+
+if [[ $REGISTRY_PASSWORD ]]; then
+        REG_PASSWORD_ARG="-p ${REGISTRY_PASSWORD}"
 fi
 
 #verify registry url
-curl $CURL_INSECURE_ARG -fsSm 3 ${REGISTRY_URL}/v2/ > /dev/null
+reg ${REG_INSECURE_ARG} ${REG_USERNAME_ARG} ${REG_PASSWORD_ARG} -r ${REGISTRY_URL} ls > /dev/null
 REGISTRY_URL_EXIT_CODE=$?
 if [ ! ${REGISTRY_URL_EXIT_CODE} -eq 0 ]; then
 	echo "Could not contact registry at ${REGISTRY_URL} - quitting"
@@ -63,9 +71,9 @@ if [ ${TOTAL_COUNT} -gt 0 ]; then
 
 		for repo in $repos; do
 			if [ ${DRY_RUN} ]; then
-				echo "Would have run curl -fsS ${CURL_INSECURE_ARG} -X DELETE ${REGISTRY_URL}/v2/${repo}/manifests/sha256:${manifest} > /dev/null"
+				echo "Would have run reg ${REG_INSECURE_ARG} ${REG_USERNAME_ARG} ${REG_PASSWORD_ARG} -r ${REGISTRY_URL} rm ${repo}@sha256:${manifest} > /dev/null"
 			else
-				curl -fsS ${CURL_INSECURE_ARG} -X DELETE ${REGISTRY_URL}/v2/${repo}/manifests/sha256:${manifest} > /dev/null
+				reg ${REG_INSECURE_ARG} ${REG_USERNAME_ARG} ${REG_PASSWORD_ARG} -r ${REGISTRY_URL} rm ${repo}@sha256:${manifest} > /dev/null
 				exit_code=$?
 
 				if [ ${exit_code} -eq 0 ]; then


### PR DESCRIPTION
Uses https://github.com/jessfraz/reg to delete the manifests instead
of curl since it already supports authentication, including
Docker registry v2 token authentication.

The optional REGISTRY_USERNAME and REGISTRY_PASSWORD environment
variables have been added.

CURL_INSECURE is still accepted for backwards compatibility.

The reg binary needs to be in the PATH.