### PR TITLE
add support for manifest lists and fix double deletions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.6
-RUN apk add --no-cache curl bash
+RUN apk add --no-cache curl bash jq
 ADD docker-registry-cleanup.sh /docker-registry-cleanup.sh
 CMD /docker-registry-cleanup.sh


### PR DESCRIPTION
Hello,

i added support for manifest lists (https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) to allow cleanup of repositories containing them.

I also lowered the number delete requests.

With regards

Joniw