### PR TITLE
Skip missing manifest file

### DIFF
--- a/docker-registry-cleanup.py
+++ b/docker-registry-cleanup.py
@@ -129,7 +129,11 @@ for filename in linked_manifest_files:
 
 	else:
 		shasum = open(filename, 'r').read().split(":")[1]
-		manifest = json.loads(open("%s/sha256/%s/%s/data" % (blob_dir, shasum[0:2], shasum)).read())
+		manifest_file = "%s/sha256/%s/%s/data" % (blob_dir, shasum[0:2], shasum)
+		if not os.path.exists(manifest_file):
+			print("Missing manifest %s referenced by %s, skipping" % (manifest_file, filename))
+			continue
+		manifest = json.loads(open(manifest_file).read())
 
 	manifest_media_type = manifest["mediaType"]
 	


### PR DESCRIPTION
We had issues in our registry with some inconsistencies between files referenced and existing files on the disk (not sure how we got in that state). This change allow to move forward with the cleanup and log the inconsistencies